### PR TITLE
bin: use ghauth for fetching token

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -9,6 +9,11 @@ const args = process.argv.splice(2)
     , home = process.env.HOME
     , usage = require('help')()
     , pkg = require('../package')
+    , ghauth = require('ghauth')
+    , authOptions = {
+        configName: 'core-get-reviewers'
+      , scopes: ['repo']
+    }
 
 if (!args.length) return usage(1)
 
@@ -21,23 +26,16 @@ if (args[0] === 'version' || args[0] === 'v' || args[0] === '--version') {
   return
 }
 
-const token = readToken()
+ghauth(authOptions, function (err, authData) {
+  var cgr = GetReviewers({
+    token: authData.token
+  })
 
-var cgr = GetReviewers({
-  token: token
+  cgr.fetchPR(args[0], function(err, out) {
+    if (err) {
+      console.error('ERR:', err)
+      process.exit(1)
+    }
+    console.log(cgr.generate(args[0], out))
+  })
 })
-
-cgr.fetchPR(args[0], function(err, out) {
-  if (err) {
-    console.error('ERR:', err)
-    process.exit(1)
-  }
-  console.log(cgr.generate(args[0], out))
-})
-
-function readToken() {
-  try {
-    return fs.readFileSync(path.join(home, '.github_token'), 'utf8').trim()
-  }
-  catch (err) {}
-}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tap test/*.js --cov"
   },
   "dependencies": {
+    "ghauth": "^3.2.0",
     "github": "~0.2.4",
     "help": "~2.1.1"
   },


### PR DESCRIPTION
This is a slight modification to the bin to use `ghauth` to simplify
the process of fetching / creating a token. I opted to put it in bin
rather than lib due to simplicity. The current architecture of lib/,
specifically having the github object being created in the constructor
does not play especially nice with the callback style of `ghauth`.

Auth happening in lib would probably be nicer, but I bet very few
will use this as a client lib so ¯\_(ツ)_/¯
